### PR TITLE
Avoid unexpected errors in `WebAuthn::PublicKeyCredential.from_client`

### DIFF
--- a/lib/webauthn/public_key_credential.rb
+++ b/lib/webauthn/public_key_credential.rb
@@ -4,9 +4,13 @@ require "webauthn/encoder"
 
 module WebAuthn
   class PublicKeyCredential
+    class RequiredError < Error; end
+
     attr_reader :type, :id, :raw_id, :client_extension_outputs, :authenticator_attachment, :response
 
     def self.from_client(credential, relying_party: WebAuthn.configuration.relying_party)
+      raise RequiredError if credential.nil?
+
       new(
         type: credential["type"],
         id: credential["id"],

--- a/spec/webauthn/public_key_credential_spec.rb
+++ b/spec/webauthn/public_key_credential_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "webauthn/public_key_credential"
+
+RSpec.describe "PublicKeyCredential" do
+  describe ".from_client" do
+    it do
+      expect do
+        WebAuthn::PublicKeyCredential.from_client(nil)
+      end.to raise_error(WebAuthn::PublicKeyCredential::RequiredError)
+    end
+  end
+end


### PR DESCRIPTION
Added an exception handling class to make troubleshooting easier for this library users.

The following error occurs when `credential` is not entered in `WebAuthn::Credential.from_create`.

```ruby
undefined method `[]' for nil:NilClass

type: credential["type"],
```

Assuming a case where credential verifies the authentication information received from an external encryption machine as is, credential may become `nil` for some reason.